### PR TITLE
Remove JSON.stringify from setOutput

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,4 +12,4 @@ const tagTo = core.getInput("to", { required: true });
 
 const changelog = exec(`node ${lernaChangelog} --from ${tagFrom} --to ${tagTo}`);
 
-core.setOutput("changelog", JSON.stringify(changelog));
+core.setOutput("changelog", changelog);


### PR DESCRIPTION
- Removed `JSON.stringify` from `setOutput` so we no longer have to `JSON.parse` on the other end